### PR TITLE
check_os.yamlでソフトとハードのファイルディスクリプタを2048以上か確認する

### DIFF
--- a/playbooks/check_dev_server_state.yaml
+++ b/playbooks/check_dev_server_state.yaml
@@ -6,3 +6,6 @@
     - name: Check Nginx State
       ansible.builtin.import_tasks:
         file: tasks/check_dev_server_state/check_nginx.yaml
+    - name: Check OS State
+      ansible.builtin.import_tasks:
+        file: tasks/check_dev_server_state/check_os.yaml

--- a/playbooks/tasks/check_dev_server_state/check_os.yaml
+++ b/playbooks/tasks/check_dev_server_state/check_os.yaml
@@ -1,0 +1,20 @@
+---
+- name: Check soft limit of filedescriptors
+  command: ulimit -n
+  register: soft_limit
+  changed_when: False
+
+- name: Verify soft limit is sufficient
+  fail:
+    msg: "Soft limit of file descriptors is less than 2048"
+    when: soft_limit.stdout|int < 2048
+
+- name: Check hard limit of file descriptors
+  command: cat /proc/sys/fsfile-max
+  register: hard_limit
+  changed_when: False
+
+- name: Verify hard limit is sufficient
+  fail:
+    msg: "Hard limit of file descriptors is less than 2048"
+    when: hard_limit.stdout|int < 2048

--- a/playbooks/tasks/check_dev_server_state/check_os.yaml
+++ b/playbooks/tasks/check_dev_server_state/check_os.yaml
@@ -1,21 +1,39 @@
 ---
 - name: Check soft limit of file descriptors
+# description: `ulimit`コマンドがshell組込みのため、commandモジュールではなくshellモジュールを使用する
   shell: ulimit -n
   register: soft_limit
   changed_when: False
 
-- name: Verify soft limit is sufficient
-  fail:
-    msg: "Soft limit of file descriptors is less than 2048"
-  when: soft_limit.stdout|int < 2048
+- name: Set fact for soft limit check
+  set_fact:
+    is_os_soft_limit_sufficient: "{{ soft_limit.stdout|int >= 2048 }}"
 
 - name: Check hard limit of file descriptors
-  shell: cat /proc/sys/fs/file-max
+  command: cat /proc/sys/fs/file-max
   register: hard_limit
   changed_when: False
 
-- name: Verify hard limit is sufficient
+- name: Set fact for hard limit check
+  set_fact:
+    is_os_hard_limit_sufficient: "{{ hard_limit.stdout|int >= 2048 }}"
+
+- name: Check if all limits are sufficient
+  set_fact:
+    is_all_os_checks_passed: "{{ is_os_soft_limit_sufficient and is_os_hard_limit_sufficient }}"
+
+- name: Show os status
+  debug:
+    msg:
+      - "Soft limit is sufficient: {{ is_os_soft_limit_sufficient }}"
+      - "Hard limit is sufficient: {{ is_os_hard_limit_sufficient }}"
+
+- name: Fail if any checks did not pass
   fail:
-    msg: "Hard limit of file descriptors is less than 2048"
-  when: hard_limit.stdout|int < 2048
-  
+    msg: "Not all os checks have passed."
+  when: not is_all_os_checks_passed
+
+- name: All checks have passed
+  debug:
+    msg: "All os checks have passed."
+  when: is_all_os_checks_passed

--- a/playbooks/tasks/check_dev_server_state/check_os.yaml
+++ b/playbooks/tasks/check_dev_server_state/check_os.yaml
@@ -5,17 +5,14 @@
   register: soft_limit
   changed_when: False
 
-- name: Set fact for soft limit check
-  set_fact:
-    is_os_soft_limit_sufficient: "{{ soft_limit.stdout|int >= 2048 }}"
-
 - name: Check hard limit of file descriptors
   command: cat /proc/sys/fs/file-max
   register: hard_limit
   changed_when: False
 
-- name: Set fact for hard limit check
+- name: Set fact for os limit check
   set_fact:
+    is_os_soft_limit_sufficient: "{{ soft_limit.stdout|int >= 2048 }}"
     is_os_hard_limit_sufficient: "{{ hard_limit.stdout|int >= 2048 }}"
 
 - name: Check if all limits are sufficient

--- a/playbooks/tasks/check_dev_server_state/check_os.yaml
+++ b/playbooks/tasks/check_dev_server_state/check_os.yaml
@@ -1,20 +1,20 @@
 ---
 - name: Check soft limit of filedescriptors
-  command: ulimit -n
+  shell: ulimit -n
   register: soft_limit
+  changed_when: False
+
+- name: Check hard limit of file descriptors
+  shell: cat /proc/sys/fsfile-max
+  register: hard_limit
   changed_when: False
 
 - name: Verify soft limit is sufficient
   fail:
     msg: "Soft limit of file descriptors is less than 2048"
-    when: soft_limit.stdout|int < 2048
-
-- name: Check hard limit of file descriptors
-  command: cat /proc/sys/fsfile-max
-  register: hard_limit
-  changed_when: False
+  when: soft_limit.stdout|int < 2048
 
 - name: Verify hard limit is sufficient
   fail:
     msg: "Hard limit of file descriptors is less than 2048"
-    when: hard_limit.stdout|int < 2048
+  when: hard_limit.stdout|int < 2048

--- a/playbooks/tasks/check_dev_server_state/check_os.yaml
+++ b/playbooks/tasks/check_dev_server_state/check_os.yaml
@@ -1,12 +1,7 @@
 ---
-- name: Check soft limit of filedescriptors
+- name: Check soft limit of file descriptors
   shell: ulimit -n
   register: soft_limit
-  changed_when: False
-
-- name: Check hard limit of file descriptors
-  shell: cat /proc/sys/fsfile-max
-  register: hard_limit
   changed_when: False
 
 - name: Verify soft limit is sufficient
@@ -14,7 +9,13 @@
     msg: "Soft limit of file descriptors is less than 2048"
   when: soft_limit.stdout|int < 2048
 
+- name: Check hard limit of file descriptors
+  shell: cat /proc/sys/fs/file-max
+  register: hard_limit
+  changed_when: False
+
 - name: Verify hard limit is sufficient
   fail:
     msg: "Hard limit of file descriptors is less than 2048"
   when: hard_limit.stdout|int < 2048
+  

--- a/test/Makefile
+++ b/test/Makefile
@@ -38,7 +38,7 @@ destroy-test-server:
 
 .PHONY: ping-test-server
 ping-test-server:
-	docker-compose run ansible-runner ansible -m ping all -i /home/ubuntu/tmp/inventory.ini --private-key="/home/ubuntu/tmp/id_ed25519"
+	docker compose run ansible-runner ansible -m ping all -i /home/ubuntu/tmp/inventory.ini --private-key="/home/ubuntu/tmp/id_ed25519"
 
 .PHONY: install-packages
 install-packages:


### PR DESCRIPTION
チェックした後の挙動はどうなるのが良いんでしょうか？
（今は2048以下だったら、Failed!でチェックが終わっちゃう。）
<img width="1386" alt="image" src="https://github.com/Tech-Residence/isucon-template/assets/16711564/5abd616d-2177-4b43-a87f-c7a99f74c19c">
